### PR TITLE
Add list-spiders cmd to shub-image

### DIFF
--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -30,11 +30,13 @@ shub utils itself).
               callback=list_targets)
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
-def cli(target, debug, version):
-    build_cmd(target, debug, version)
+@click.pass_context
+def cli(ctx, target, debug, version):
+    ctx.obj = {'debug': debug}
+    build_cmd(target, version)
 
 
-def build_cmd(target, debug, version):
+def build_cmd(target, version):
     client = utils.get_docker_client()
     project_dir = utils.get_project_dir()
     config = utils.load_release_config()
@@ -47,8 +49,7 @@ def build_cmd(target, debug, version):
     for line in client.build(path=project_dir, tag=image_name):
         data = json.loads(line)
         if 'stream' in data:
-            if debug:
-                click.echo("{}".format(data['stream'][:-1]))
+            utils.debug_log("{}".format(data['stream'][:-1]))
             is_built = re.search(
                 r'Successfully built ([0-9a-f]+)', data['stream'])
         elif 'error' in data:

--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -30,9 +30,7 @@ shub utils itself).
               callback=list_targets)
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
-@click.pass_context
-def cli(ctx, target, debug, version):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, version):
     build_cmd(target, version)
 
 

--- a/shub_image/deploy.py
+++ b/shub_image/deploy.py
@@ -49,9 +49,7 @@ Does a simple POST request to Dash API with given parameters
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
 @click.option("--async", is_flag=True, help="enable asynchronous mode")
-@click.pass_context
-def cli(ctx, target, debug, version, username, password, email, async):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, version, username, password, email, async):
     deploy_cmd(target, version, username, password, email, async)
 
 

--- a/shub_image/deploy.py
+++ b/shub_image/deploy.py
@@ -113,6 +113,7 @@ def _check_status_url(status_url):
 
 def _prepare_deploy_params(project, version, image_name, endpoint, apikey,
                            username, password, email, debug):
+    # Reusing shub_image.list logic to get spiders list
     spiders = list_cmd(image_name, project, endpoint, apikey, debug)
     scripts = _extract_scripts_from_project()
     params = {'project': project,

--- a/shub_image/deploy.py
+++ b/shub_image/deploy.py
@@ -12,7 +12,7 @@ from retrying import retry
 
 from shub.deploy import list_targets
 from shub_image import utils
-from shub_image.list import list_cmd
+from shub_image import list as list_mod
 
 
 VALIDSPIDERNAME = re.compile('^[a-z0-9][-._a-z0-9]+$', re.I)
@@ -114,13 +114,13 @@ def _check_status_url(status_url):
 def _prepare_deploy_params(project, version, image_name, endpoint, apikey,
                            username, password, email, debug):
     # Reusing shub_image.list logic to get spiders list
-    spiders = list_cmd(image_name, project, endpoint, apikey, debug)
+    spiders = list_mod.list_cmd(image_name, project, endpoint, apikey, debug)
     scripts = _extract_scripts_from_project()
     params = {'project': project,
               'version': version,
               'image_url': image_name}
     if spiders:
-        params['spiders'] = spiders
+        params['spiders'] = ','.join(spiders)
     if scripts:
         params['scripts'] = scripts
     if not username:

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -39,9 +39,7 @@ shub utils itself).
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("-s", "--silent", help="silent mode", is_flag=True)
 @click.option("--version", help="release version")
-@click.pass_context
-def cli(ctx, target, debug, silent, version):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, silent, version):
     list_cmd_full(target, silent, version)
 
 

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -50,7 +50,7 @@ def list_cmd_full(target, debug, version):
     # FIXME there can be a case when there's no project specified
     # for the target, in this case we should notify about it and
     # skip getting settings from Dash.
-    project = None
+    project, endpoint, apikey = None, None, None
     try:
         project, endpoint, apikey = config.get_target(target)
     except shub_exceptions.BadParameterException as exc:

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -1,0 +1,111 @@
+import os
+import re
+import click
+import requests
+from urlparse import urljoin
+
+from shub import exceptions as shub_exceptions
+from shub.deploy import list_targets
+from shub_image import utils
+
+
+SETTING_TYPES = ['project_settings',
+                 'organization_settings',
+                 'enabled_addons']
+
+SHORT_HELP = 'List spiders.'
+
+HELP = """
+List command tries to run your image locally and get a spiders list.
+
+Internally, this command is a simple wrapper to `docker run` and uses
+docker daemon on your system to run a new container using your image.
+Before creating the container, there's a Dash call to get your project
+settings to get your spiders list properly (respecting SPIDERS_MODULE
+setting, etc).
+
+Image should be set via scrapinghub.yml, section "images". If version is not
+provided, the tool uses VCS-based stamp over project directory (the same as
+shub utils itself).
+"""
+
+
+@click.command(help=HELP, short_help=SHORT_HELP)
+@click.argument("target", required=False, default="default")
+@click.option("-l", "--list-targets", help="list available targets",
+              is_flag=True, is_eager=True, expose_value=False,
+              callback=list_targets)
+@click.option("-d", "--debug", help="debug mode", is_flag=True)
+@click.option("--version", help="release version")
+def cli(target, debug, version):
+    list_cmd(target, debug, version)
+
+
+def list_cmd(target, debug, version):
+    config = utils.load_release_config()
+    image = config.get_image(target)
+    version = version or config.get_version()
+    image_name = utils.format_image_name(image, version)
+
+    project, settings = 'none', {}
+    # Get project settings from Dash if there's a project
+    try:
+        project, endpoint, apikey = config.get_target(target)
+    except shub_exceptions.BadParameterException as exc:
+        if 'Could not find target' in exc.message:
+            click.echo(
+                "Not found project for target {}, "
+                "not getting project settings from Dash.".format(target))
+        else:
+            raise
+    else:
+        settings = _get_project_settings(project, endpoint, apikey, debug)
+
+    # Run a local docker container to run list-spiders cmd
+    status_code, logs = _run_list_cmd(project, image_name, settings)
+    if status_code != 0:
+        raise shub_exceptions.ShubException('List exit code: %s' % status_code)
+
+    spiders = utils.valid_spiders(logs)
+    for spider in spiders:
+        click.echo(spider)
+
+
+def _get_project_settings(project, endpoint, apikey, debug):
+    if debug:
+        click.echo('Getting settings for {} project:'.format(project))
+    req = requests.get(
+        urljoin(endpoint, '/api/settings/get.json'),
+        params={'project': project},
+        auth=(apikey, ''),
+        timeout=300,
+        allow_redirects=False
+    )
+    req.raise_for_status()
+    if debug:
+        click.echo("Response: {}".format(req.json()))
+    return {k: v for k, v in req.json().items() if k in SETTING_TYPES}
+
+
+def _run_list_cmd(project, image_name, project_settings):
+    """Run `scrapy list` command inside the image container."""
+
+    client = utils.get_docker_client()
+    job_settings = utils.datauri(project_settings)
+    container = client.create_container(
+        image=image_name,
+        command=['list-spiders'],
+        environment={'SCRAPY_PROJECT_ID': str(project),
+                     'JOB_SETTINGS': job_settings}
+    )
+    if 'Id' not in container:
+        raise shub_exceptions.ShubException(
+            "Create container error:\n %s" % container)
+
+    client.start(container)
+    statuscode = client.wait(container=container['Id'])
+
+    return statuscode, client.logs(
+            container=container['Id'],
+            stdout=True, stderr=True if statuscode else False,
+            stream=False, timestamps=False)

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -47,8 +47,10 @@ def list_cmd_full(target, debug, version):
     version = version or config.get_version()
     image_name = utils.format_image_name(image, version)
 
+    # FIXME there can be a case when there's no project specified
+    # for the target, in this case we should notify about it and
+    # skip getting settings from Dash.
     project = None
-    # Get project settings from Dash if there's a project
     try:
         project, endpoint, apikey = config.get_target(target)
     except shub_exceptions.BadParameterException as exc:
@@ -71,7 +73,8 @@ def list_cmd(image_name, project, endpoint, apikey, debug):
     status_code, logs = _run_list_cmd(project, image_name, settings)
     if status_code != 0:
         click.echo(logs)
-        raise shub_exceptions.ShubException('List exit code: %s' % status_code)
+        raise shub_exceptions.ShubException(
+            'Container with list cmd exited with code %s' % status_code)
 
     spiders = utils.valid_spiders(logs)
     for spider in spiders:

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -38,16 +38,16 @@ shub utils itself).
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
 def cli(target, debug, version):
-    list_cmd(target, debug, version)
+    list_cmd_full(target, debug, version)
 
 
-def list_cmd(target, debug, version):
+def list_cmd_full(target, debug, version):
     config = utils.load_release_config()
     image = config.get_image(target)
     version = version or config.get_version()
     image_name = utils.format_image_name(image, version)
 
-    project, settings = None, {}
+    project = None
     # Get project settings from Dash if there's a project
     try:
         project, endpoint, apikey = config.get_target(target)
@@ -57,7 +57,14 @@ def list_cmd(target, debug, version):
         click.echo(
             "Not found project for target {}, "
             "not getting project settings from Dash.".format(target))
-    else:
+    list_cmd(image_name, project, endpoint, apikey, debug)
+
+
+def list_cmd(image_name, project, endpoint, apikey, debug):
+    """Short version of list cmd to use with deploy cmd."""
+
+    settings = {}
+    if project:
         settings = _get_project_settings(project, endpoint, apikey, debug)
 
     # Run a local docker container to run list-spiders cmd

--- a/shub_image/list.py
+++ b/shub_image/list.py
@@ -1,5 +1,6 @@
 import os
 import re
+import json
 import click
 import requests
 from urlparse import urljoin
@@ -103,7 +104,7 @@ def _run_list_cmd(project, image_name, project_settings):
     # FIXME we should pass some value for SCRAPY_PROJECT_ID anyway
     # to handle `scrapy list` cmd properly via sh_scrapy entrypoint
     project = str(project) if project else ''
-    job_settings = utils.datauri(project_settings)
+    job_settings = json.dumps(project_settings)
     container = client.create_container(
         image=image_name,
         command=['list-spiders'],

--- a/shub_image/push.py
+++ b/shub_image/push.py
@@ -30,9 +30,7 @@ otherwise you have to enter your credentials (at least username/password).
 @click.option("--username", help="docker registry name")
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
-@click.pass_context
-def cli(ctx, target, debug, version, username, password, email):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, version, username, password, email):
     push_cmd(target, version, username, password, email)
 
 

--- a/shub_image/push.py
+++ b/shub_image/push.py
@@ -30,11 +30,13 @@ otherwise you have to enter your credentials (at least username/password).
 @click.option("--username", help="docker registry name")
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
-def cli(target, debug, version, username, password, email):
-    push_cmd(target, debug, version, username, password, email)
+@click.pass_context
+def cli(ctx, target, debug, version, username, password, email):
+    ctx.obj = {'debug': debug}
+    push_cmd(target, version, username, password, email)
 
 
-def push_cmd(target, debug, version, username, password, email):
+def push_cmd(target, version, username, password, email):
     client = utils.get_docker_client()
     config = utils.load_release_config()
     image = config.get_image(target)
@@ -45,9 +47,9 @@ def push_cmd(target, debug, version, username, password, email):
     for line in client.push(image_name, stream=True,
                             insecure_registry=not bool(username)):
         data = json.loads(line)
-        if 'status' in data and debug:
-            click.echo("Logs:{} {}".format(data['status'],
-                                           data.get('progress')))
+        if 'status' in data:
+            utils.debug_log("Logs:{} {}".format(data['status'],
+                            data.get('progress')))
         if 'error' in data:
             click.echo("Error {}: {}".format(data['error'],
                                              data['errorDetail']))

--- a/shub_image/test.py
+++ b/shub_image/test.py
@@ -19,7 +19,9 @@ SH_EP_SCRAPY_WARNING = \
               callback=list_targets)
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
-def cli(target, debug, version):
+@click.pass_context
+def cli(ctx, target, debug, version):
+    ctx.obj = {'debug': debug}
     config = utils.load_release_config()
     image = config.get_image(target)
     version = version or config.get_version()
@@ -29,10 +31,10 @@ def cli(target, debug, version):
                   _check_start_crawl_entry,
                   _check_list_spiders_entry,
                   _check_sh_entrypoint]:
-        check(image_name, docker_client, debug)
+        check(image_name, docker_client)
 
 
-def _check_image_exists(image_name, docker_client, debug):
+def _check_image_exists(image_name, docker_client):
     """Check that the image exists on local machine."""
     # if there's no docker lib, the command will fail earlier
     # with an exception when getting a client in get_docker_client()
@@ -40,42 +42,41 @@ def _check_image_exists(image_name, docker_client, debug):
     try:
         docker_client.inspect_image(image_name)
     except NotFound as exc:
-        if debug:
-            click.echo("{}".format(exc))
+        utils.debug_log("{}".format(exc))
         raise shub_exceptions.NotFoundException(
             "The image doesn't exist yet, please use build command at first.")
 
 
-def _check_sh_entrypoint(image_name, docker_client, debug):
+def _check_sh_entrypoint(image_name, docker_client):
     """Check that the image has scrapinghub-entrypoint-scrapy pkg"""
     status, logs = _run_docker_command(
         docker_client, image_name,
-        ['pip', 'show', 'scrapinghub-entrypoint-scrapy'], debug)
+        ['pip', 'show', 'scrapinghub-entrypoint-scrapy'])
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(SH_EP_SCRAPY_WARNING)
 
 
-def _check_list_spiders_entry(image_name, docker_client, debug):
+def _check_list_spiders_entry(image_name, docker_client):
     """Check that the image has list-spiders entrypoint"""
     status, logs = _run_docker_command(
-        docker_client, image_name, ['which', 'list-spiders'], debug)
+        docker_client, image_name, ['which', 'list-spiders'])
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(
             "list-spiders command is not found in the image.\n"
             "Please upgrade your scrapinghub-entrypoint-scrapy.")
 
 
-def _check_start_crawl_entry(image_name, docker_client, debug):
+def _check_start_crawl_entry(image_name, docker_client):
     """Check that the image has start-crawl entrypoint"""
     status, logs = _run_docker_command(
-        docker_client, image_name, ['which', 'start-crawl'], debug)
+        docker_client, image_name, ['which', 'start-crawl'])
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(
             "start-crawl command is not found in the image.\n"
             + SH_EP_SCRAPY_WARNING)
 
 
-def _run_docker_command(client, image_name, command, debug):
+def _run_docker_command(client, image_name, command):
     """A helper to execute an arbitrary cmd with given docker image"""
     container = client.create_container(image=image_name, command=command)
     client.start(container)
@@ -83,6 +84,5 @@ def _run_docker_command(client, image_name, command, debug):
     logs = client.logs(container=container['Id'], stdout=True,
                        stderr=True if statuscode else False,
                        stream=False, timestamps=False)
-    if debug:
-        click.echo("{} results:\n{}".format(command, logs))
+    utils.debug_log("{} results:\n{}".format(command, logs))
     return statuscode, logs

--- a/shub_image/test.py
+++ b/shub_image/test.py
@@ -20,9 +20,7 @@ SH_EP_SCRAPY_WARNING = \
               callback=list_targets)
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
-@click.pass_context
-def cli(ctx, target, debug, version):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, version):
     config = utils.load_release_config()
     image = config.get_image(target)
     version = version or config.get_version()

--- a/shub_image/test.py
+++ b/shub_image/test.py
@@ -8,8 +8,9 @@ SHORT_HELP = "Test a built image with Scrapy Cloud contract"
 HELP = """ TODO """
 
 SH_EP_SCRAPY_WARNING = \
-    'You should add scrapinghub-entrypoint-scrapy dependency to your' \
-    ' requirements.txt or to Dockerfile to run the image with Scrapy Cloud'
+    'You should add scrapinghub-entrypoint-scrapy(>=0.7.0) dependency' \
+    ' to your requirements.txt or to Dockerfile to run the image with' \
+    ' Scrapy Cloud.'
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)
@@ -63,7 +64,7 @@ def _check_list_spiders_entry(image_name, docker_client):
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(
             "list-spiders command is not found in the image.\n"
-            "Please upgrade your scrapinghub-entrypoint-scrapy.")
+            "Please upgrade your scrapinghub-entrypoint-scrapy(>=0.7.0)")
 
 
 def _check_start_crawl_entry(image_name, docker_client):

--- a/shub_image/test.py
+++ b/shub_image/test.py
@@ -9,8 +9,7 @@ HELP = """ TODO """
 
 SH_EP_SCRAPY_WARNING = \
     'You should add scrapinghub-entrypoint-scrapy dependency to your' \
-    ' requirements.txt or to Dockerfile to run the image with Scrapy Cloud\n' \
-    '  (git+https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy.git)'
+    ' requirements.txt or to Dockerfile to run the image with Scrapy Cloud'
 
 
 @click.command(help=HELP, short_help=SHORT_HELP)
@@ -28,6 +27,7 @@ def cli(target, debug, version):
     docker_client = utils.get_docker_client()
     for check in [_check_image_exists,
                   _check_start_crawl_entry,
+                  _check_list_spiders_entry,
                   _check_sh_entrypoint]:
         check(image_name, docker_client, debug)
 
@@ -53,6 +53,16 @@ def _check_sh_entrypoint(image_name, docker_client, debug):
         ['pip', 'show', 'scrapinghub-entrypoint-scrapy'], debug)
     if status != 0 or not logs:
         raise shub_exceptions.NotFoundException(SH_EP_SCRAPY_WARNING)
+
+
+def _check_list_spiders_entry(image_name, docker_client, debug):
+    """Check that the image has list-spiders entrypoint"""
+    status, logs = _run_docker_command(
+        docker_client, image_name, ['which', 'list-spiders'], debug)
+    if status != 0 or not logs:
+        raise shub_exceptions.NotFoundException(
+            "list-spiders command is not found in the image.\n"
+            "Please upgrade your scrapinghub-entrypoint-scrapy.")
 
 
 def _check_start_crawl_entry(image_name, docker_client, debug):

--- a/shub_image/tool.py
+++ b/shub_image/tool.py
@@ -28,8 +28,8 @@ module_deps = {
     "list": ["docker"],
     "test": ["docker"],
     "push": ["docker"],
-    "deploy": ["scrapy"],
-    "upload": ["scrapy", "docker"],
+    "deploy": ["docker"],
+    "upload": ["docker"],
     "check": [],
 }
 

--- a/shub_image/tool.py
+++ b/shub_image/tool.py
@@ -25,6 +25,7 @@ def cli():
 module_deps = {
     "init": [],
     "build": ["docker"],
+    "list": ["docker"],
     "test": ["docker"],
     "push": ["docker"],
     "deploy": ["scrapy"],

--- a/shub_image/upload.py
+++ b/shub_image/upload.py
@@ -26,7 +26,9 @@ Obviously it accepts all the options for the commands above.
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
 @click.option("--async", is_flag=True, help="enable asynchronous mode")
-def cli(target, debug, version, username, password, email, async):
-    build.build_cmd(target, debug, version)
-    push.push_cmd(target, debug, version, username, password, email)
-    deploy.deploy_cmd(target, debug, version, username, password, email, async)
+@click.pass_context
+def cli(ctx, target, debug, version, username, password, email, async):
+    ctx.obj = {'debug': debug}
+    build.build_cmd(target, version)
+    push.push_cmd(target, version, username, password, email)
+    deploy.deploy_cmd(target, version, username, password, email, async)

--- a/shub_image/upload.py
+++ b/shub_image/upload.py
@@ -26,9 +26,7 @@ Obviously it accepts all the options for the commands above.
 @click.option("--password", help="docker registry password")
 @click.option("--email", help="docker registry email")
 @click.option("--async", is_flag=True, help="enable asynchronous mode")
-@click.pass_context
-def cli(ctx, target, debug, version, username, password, email, async):
-    ctx.obj = {'debug': debug}
+def cli(target, debug, version, username, password, email, async):
     build.build_cmd(target, version)
     push.push_cmd(target, version, username, password, email)
     deploy.deploy_cmd(target, version, username, password, email, async)

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -17,6 +17,12 @@ STATUS_FILE_LOCATION = '.releases'
 _VALIDSPIDERNAME = re.compile('^[a-z0-9][-._a-z0-9]+$', re.I)
 
 
+def debug_log(msg):
+    ctx = click.get_current_context()
+    if ctx.obj and ctx.obj.get('debug'):
+        click.echo(msg)
+
+
 class ReleaseConfig(shub_config.ShubConfig):
 
     def __init__(self, *args, **kwargs):

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -18,7 +18,7 @@ _VALIDSPIDERNAME = re.compile('^[a-z0-9][-._a-z0-9]+$', re.I)
 
 def debug_log(msg):
     ctx = click.get_current_context(True)
-    if hasattr(ctx, 'obj') and ctx.obj.get('debug'):
+    if ctx and ctx.params.get('debug'):
         click.echo(msg)
 
 

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -17,8 +17,8 @@ _VALIDSPIDERNAME = re.compile('^[a-z0-9][-._a-z0-9]+$', re.I)
 
 
 def debug_log(msg):
-    ctx = click.get_current_context()
-    if ctx.obj and ctx.obj.get('debug'):
+    ctx = click.get_current_context(True)
+    if hasattr(ctx, 'obj') and ctx.obj.get('debug'):
         click.echo(msg)
 
 

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -4,7 +4,6 @@ import json
 import click
 import importlib
 
-from base64 import b64encode
 import ruamel.yaml as yaml
 
 from shub import config as shub_config
@@ -190,14 +189,3 @@ def valid_spiders(buf):
     ['A77aque']
     """
     return sorted(filter(_VALIDSPIDERNAME.match, buf.splitlines()))
-
-
-def datauri(content, mime_type='application/json',
-            charset='utf8', base64=True):
-    if isinstance(content, dict) and mime_type == 'application/json':
-        content = json.dumps(content)
-    if isinstance(content, unicode):
-        content = content.encode(charset)
-    if base64:
-        content = 'base64,{}'.format(b64encode(content))
-    return 'data:{};{};{}'.format(mime_type, charset, content)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -58,7 +58,7 @@ class TestDeployTools(TestCase):
             add_fake_setup_py(tmpdir)
             assert _prepare_deploy_params(
                 123, 'test-vers', 'registry/user/project',
-                'endpoint', 'apikey', None, None, None, False) == {
+                'endpoint', 'apikey', None, None, None) == {
                     'image_url': 'registry/user/project',
                     'project': 123,
                     'pull_insecure_registry': True,
@@ -75,7 +75,7 @@ class TestDeployTools(TestCase):
                              ' "pass", "username": "user"}')
             assert _prepare_deploy_params(
                 123, 'test-vers', 'registry/user/project',
-                'endpoint', 'apikey', 'user', 'pass', 'email@mail', False) == {
+                'endpoint', 'apikey', 'user', 'pass', 'email@mail') == {
                     'image_url': 'registry/user/project',
                     'project': 123,
                     'pull_auth_config': expected_auth,

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -2,7 +2,6 @@ import os
 import mock
 from click.testing import CliRunner
 from unittest import TestCase
-from subprocess import CalledProcessError
 
 from shub_image.deploy import cli
 from shub_image.deploy import _prepare_deploy_params
@@ -12,6 +11,7 @@ from .utils import FakeProjectDirectory
 from .utils import add_sh_fake_config
 from .utils import add_fake_setup_py
 from .utils import add_scrapy_fake_config
+
 
 class TestDeployCli(TestCase):
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -6,7 +6,6 @@ from subprocess import CalledProcessError
 
 from shub_image.deploy import cli
 from shub_image.deploy import _prepare_deploy_params
-from shub_image.deploy import _extract_spiders_from_project
 from shub_image.deploy import _extract_scripts_from_project
 
 from .utils import FakeProjectDirectory
@@ -18,9 +17,9 @@ class TestDeployCli(TestCase):
 
     @mock.patch('requests.get')
     @mock.patch('requests.post')
-    @mock.patch('subprocess.check_output')
-    def test_cli(self, subp_mocked, post_mocked, get_mocked):
-        subp_mocked.return_value = 'abc\na1f\njust row\nSome text\nspi-der'
+    @mock.patch('shub_image.list.list_cmd')
+    def test_cli(self, list_mocked, post_mocked, get_mocked):
+        list_mocked.return_value = ['a1f', 'abc', 'spi-der']
         post_req = mock.Mock()
         post_req.headers = {'location': 'https://status-url'}
         post_mocked.return_value = post_req
@@ -46,27 +45,20 @@ class TestDeployCli(TestCase):
 
 class TestDeployTools(TestCase):
 
-    @mock.patch('subprocess.check_output')
-    def test_extract_spiders_from_project(self, mocked):
-        mocked.return_value = 'abc\na1f\njust row\nSome text\nspi-der'
-        assert _extract_spiders_from_project() == 'a1f,abc,spi-der'
-        mocked.side_effect = CalledProcessError(-1, ['scrapy', 'list'])
-        assert _extract_spiders_from_project() == ''
-
     def test_extract_scripts_from_project(self):
         assert _extract_scripts_from_project() == ''
         with FakeProjectDirectory() as tmpdir:
             add_fake_setup_py(tmpdir)
             assert _extract_scripts_from_project() == 'scriptA.py,scriptB.py'
 
-    @mock.patch('subprocess.check_output')
+    @mock.patch('shub_image.list.list_cmd')
     def test_prepare_deploy_params(self, mocked):
-        mocked.return_value = 'abc\na1f\njust row\nSome text\nspi-der'
+        mocked.return_value = ['a1f', 'abc', 'spi-der']
         with FakeProjectDirectory() as tmpdir:
             add_fake_setup_py(tmpdir)
             assert _prepare_deploy_params(
                 123, 'test-vers', 'registry/user/project',
-                None, None, None) == {
+                'endpoint', 'apikey', None, None, None, False) == {
                     'image_url': 'registry/user/project',
                     'project': 123,
                     'pull_insecure_registry': True,
@@ -74,16 +66,16 @@ class TestDeployTools(TestCase):
                     'spiders': 'a1f,abc,spi-der',
                     'version': 'test-vers'}
 
-    @mock.patch('subprocess.check_output')
+    @mock.patch('shub_image.list.list_cmd')
     def test_prepare_deploy_params_more_params(self, mocked):
-        mocked.return_value = 'abc\na1f\njust row\nSome text\nspi-der'
+        mocked.return_value = ['a1f', 'abc', 'spi-der']
         with FakeProjectDirectory() as tmpdir:
             add_fake_setup_py(tmpdir)
             expected_auth = ('{"email": "email@mail", "password":'
                              ' "pass", "username": "user"}')
             assert _prepare_deploy_params(
                 123, 'test-vers', 'registry/user/project',
-                'user', 'pass', 'email@mail') == {
+                'endpoint', 'apikey', 'user', 'pass', 'email@mail', False) == {
                     'image_url': 'registry/user/project',
                     'project': 123,
                     'pull_auth_config': expected_auth,

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,102 @@
+import os
+import mock
+from click.testing import CliRunner
+from unittest import TestCase
+
+from shub_image.list import cli, list_cmd
+from shub_image.list import _run_list_cmd
+from shub_image.list import _get_project_settings
+
+from .utils import FakeProjectDirectory
+from .utils import add_sh_fake_config
+
+
+class TestListCli(TestCase):
+
+    def test_cli_no_sh_config(self):
+        with FakeProjectDirectory() as tmpdir:
+            runner = CliRunner()
+            result = runner.invoke(cli, ["dev", "-d", "--version", "test"])
+            assert result.exit_code == 69
+            assert 'Could not find image for dev' in result.output
+
+    @mock.patch('shub_image.utils.get_docker_client')
+    @mock.patch('requests.get')
+    def test_cli_no_project(self, get_mocked, get_client_mock):
+        client_mock = mock.Mock()
+        client_mock.create_container.return_value = {'Id': '1234'}
+        client_mock.wait.return_value = 0
+        client_mock.logs.return_value = 'abc\ndef'
+        get_client_mock.return_value = client_mock
+
+        with FakeProjectDirectory() as tmpdir:
+            add_sh_fake_config(tmpdir)
+            runner = CliRunner()
+            result = runner.invoke(cli, ["xyz", "--version", "test"])
+            assert result.exit_code == 0
+            assert result.output.endswith('abc\ndef\n')
+        assert not get_mocked.called
+
+    @mock.patch('shub_image.utils.get_docker_client')
+    @mock.patch('requests.get')
+    def test_cli_container_error(self, get_mocked, get_client_mock):
+        client_mock = mock.Mock()
+        client_mock.create_container.return_value = {'Id': '1234'}
+        client_mock.wait.return_value = 66
+        get_client_mock.return_value = client_mock
+
+        get_settings_mock = mock.Mock()
+        get_settings_mock.json.return_value = {}
+        get_mocked.return_value = get_settings_mock
+
+        with FakeProjectDirectory() as tmpdir:
+            add_sh_fake_config(tmpdir)
+            runner = CliRunner()
+            result = runner.invoke(cli, ["dev", "-d", "--version", "test"])
+            assert result.exit_code == 1
+            assert 'list cmd exited with code 66' in result.output
+
+    @mock.patch('shub_image.utils.get_docker_client')
+    @mock.patch('requests.get')
+    def test_cli(self, get_mocked, get_client_mock):
+        client_mock = mock.Mock()
+        client_mock.create_container.return_value = {'Id': '1234'}
+        client_mock.wait.return_value = 0
+        client_mock.logs.return_value = 'abc\ndef\ndsd'
+        get_client_mock.return_value = client_mock
+
+        get_settings_mock = mock.Mock()
+        get_settings_mock.json.return_value = {}
+        get_mocked.return_value = get_settings_mock
+
+        with FakeProjectDirectory() as tmpdir:
+            add_sh_fake_config(tmpdir)
+            runner = CliRunner()
+            result = runner.invoke(cli, ["dev", "-d", "--version", "test"])
+            assert result.exit_code == 0
+            assert result.output.endswith('abc\ndef\ndsd\n')
+        get_mocked.assert_called_with(
+            'https://dash.scrapinghub.com/api/settings/get.json',
+            allow_redirects=False, auth=('abcdef', ''),
+            params={'project': 12345}, timeout=300)
+
+
+class TestListCmd(TestCase):
+    
+    @mock.patch('shub_image.utils.get_docker_client')
+    def test_run_list_cmd(self, get_client_mock):
+        client_mock = mock.Mock()
+        client_mock.create_container.return_value = {'Id': '1234'}
+        client_mock.wait.return_value = 0
+        client_mock.logs.return_value = 'abc\ndef\ndsd'
+        get_client_mock.return_value = client_mock
+        assert _run_list_cmd(1234, 'image', {})[0] == 0
+        client_mock.create_container.assert_called_with(
+            command=['list-spiders'], environment={
+                'JOB_SETTINGS': 'data:application/json;utf8;base64,e30=',
+                'SCRAPY_PROJECT_ID': '1234'}, image='image')
+        client_mock.start.assert_called_with({'Id': '1234'})
+        client_mock.wait.assert_called_with(container="1234")
+        client_mock.logs.assert_called_with(
+            container='1234', stderr=False, stdout=True,
+            stream=False, timestamps=False)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -94,7 +94,7 @@ class TestListCmd(TestCase):
         assert _run_list_cmd(1234, 'image', {})[0] == 0
         client_mock.create_container.assert_called_with(
             command=['list-spiders'], environment={
-                'JOB_SETTINGS': 'data:application/json;utf8;base64,e30=',
+                'JOB_SETTINGS': '{}',
                 'SCRAPY_PROJECT_ID': '1234'}, image='image')
         client_mock.start.assert_called_with({'Id': '1234'})
         client_mock.wait.assert_called_with(container="1234")

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -72,7 +72,8 @@ class TestListCli(TestCase):
         with FakeProjectDirectory() as tmpdir:
             add_sh_fake_config(tmpdir)
             runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "-d", "--version", "test"])
+            result = runner.invoke(cli, [
+                "dev", "-d", "-s", "--version", "test"])
             assert result.exit_code == 0
             assert result.output.endswith('abc\ndef\ndsd\n')
         get_mocked.assert_called_with(

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -66,39 +66,39 @@ class TestTestTools(TestCase):
         # patching built-in import to use fake docker.errors
         import_mock = _mock_docker_errors_module()
         with mock.patch('__builtin__.__import__', side_effect=import_mock):
-            assert _check_image_exists('img', self.client, True) == None
+            assert _check_image_exists('img', self.client) == None
             self.client.inspect_image.side_effect = MockedNotFound()
             self.assertRaises(shub_exceptions.NotFoundException,
-                _check_image_exists, 'image', self.client, True)
+                _check_image_exists, 'image', self.client)
 
     def test_check_sh_entrypoint(self):
-        assert _check_sh_entrypoint('image', self.client, True) == None
+        assert _check_sh_entrypoint('image', self.client) == None
         self.client.create_container.assert_called_with(
             image='image',
             command=['pip', 'show', 'scrapinghub-entrypoint-scrapy'])
         self.client.wait.return_value = 1
         self.assertRaises(shub_exceptions.NotFoundException,
-            _check_sh_entrypoint, 'image', self.client, True)
+            _check_sh_entrypoint, 'image', self.client)
         self.client.wait.return_value = 0
         self.client.logs.return_value = ''
         self.assertRaises(shub_exceptions.NotFoundException,
-            _check_sh_entrypoint, 'image', self.client, True)
+            _check_sh_entrypoint, 'image', self.client)
 
     def test_start_crawl(self):
-        assert _check_start_crawl_entry('image', self.client, True) == None
+        assert _check_start_crawl_entry('image', self.client) == None
         self.client.create_container.assert_called_with(
             image='image', command=['which', 'start-crawl'])
         self.client.wait.return_value = 1
         self.assertRaises(shub_exceptions.NotFoundException,
-            _check_start_crawl_entry, 'image', self.client, True)
+            _check_start_crawl_entry, 'image', self.client)
         self.client.wait.return_value = 0
         self.client.logs.return_value = ''
         self.assertRaises(shub_exceptions.NotFoundException,
-            _check_start_crawl_entry, 'image', self.client, True)
+            _check_start_crawl_entry, 'image', self.client)
 
     def test_run_docker_command(self):
         assert _run_docker_command(
-            self.client, 'image-name', ['some', 'cmd'], True) == \
+            self.client, 'image-name', ['some', 'cmd']) == \
                 (0, 'some-logs')
         self.client.create_container.assert_called_with(
             image='image-name', command=['some', 'cmd'])

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -19,7 +19,6 @@ class TestUploadCli(TestCase):
                   "--username", "user", "--password", "pass",
                   "--email", "mail", "--async"])
         assert result.exit_code == 0
-        build.assert_called_with('dev', True, 'test')
-        push.assert_called_with('dev', True, 'test', 'user', 'pass', 'mail')
-        deploy.assert_called_with('dev', True, 'test', 'user',
-                                  'pass', 'mail', True)
+        build.assert_called_with('dev', 'test')
+        push.assert_called_with('dev', 'test', 'user', 'pass', 'mail')
+        deploy.assert_called_with('dev', 'test', 'user', 'pass', 'mail', True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,29 @@ import tempfile
 from contextlib import contextmanager
 
 
+SH_CONFIG_FILE = """
+projects:
+  dev: 12345
+images:
+  dev: registry/user/project
+  xyz: registry/xyz/project
+endpoints:
+  dev: https://dash-fake
+apikeys:
+  default: abcdef
+version: GIT
+"""
+
+SH_SETUP_FILE = """
+from setuptools import setup
+setup(
+    name = 'project', version = '1.0',
+    entry_points = {'scrapy': ['settings = test.settings']},
+    scripts = ['bin/scriptA.py', 'scriptB.py']
+)
+"""
+
+
 @contextmanager
 def FakeProjectDirectory():
     tmpdir = tempfile.mkdtemp()
@@ -26,13 +49,7 @@ def add_sh_fake_config(tmpdir):
     # add fake SH config
     sh_config_path = os.path.join(tmpdir, 'scrapinghub.yml')
     with open(sh_config_path, 'w') as sh_config_file:
-        sh_config_file.write('\n'.join([
-            "projects:", "  dev: 12345", "images:",
-            "  dev: registry/user/project",
-            "  xyz: registry/xyz/project",
-            "endpoints:", "  dev: https://dash-fake",
-            "apikeys:", "  default: abcdef",
-            "version: GIT"]))
+        sh_config_file.write(SH_CONFIG_FILE)
 
 
 def add_fake_requirements(tmpdir):
@@ -53,9 +70,4 @@ def add_fake_setup_py(tmpdir):
     """Add fake setup.py for extract scripts tests"""
     setup_path = os.path.join(tmpdir, 'setup.py')
     with open(setup_path, 'w') as setup_file:
-        setup_file.write('\n'.join([
-            "from setuptools import setup",
-            "setup(name = 'project', version = '1.0',",
-            "entry_points = {'scrapy': ['settings = test.settings']},",
-            "scripts = ['bin/scriptA.py', 'scriptB.py'])"
-        ]))
+        setup_file.write(SH_SETUP_FILE)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,8 +27,9 @@ def add_sh_fake_config(tmpdir):
     sh_config_path = os.path.join(tmpdir, 'scrapinghub.yml')
     with open(sh_config_path, 'w') as sh_config_file:
         sh_config_file.write('\n'.join([
-            "projects:", "  dev: 12345",
-            "images:", "  dev: registry/user/project",
+            "projects:", "  dev: 12345", "images:",
+            "  dev: registry/user/project",
+            "  xyz: registry/xyz/project",
             "endpoints:", "  dev: https://dash-fake",
             "apikeys:", "  default: abcdef",
             "version: GIT"]))


### PR DESCRIPTION
This PR adds using `list-spiders` image entrypoint in shub-image tool to get spiders list more properly.

There're the following changes:
- new `shub-image list` command to show a spiders list locally
- to make it work the tool creates a new docker container locally and run `list-spiders` cmd there
- if project id is provided in scrapinghub.yml for the target, the `list` gets project settings from Dash and respects them too (e.g. `SPIDERS_MODULE` setting)
- the `list` cmd logic is reused in `deploy` / `upload` cmds
- updated `test` cmd checks if there's `list-spiders` entrypoint in the image 
- now it's not required to have Scrapy and all of the project deps installed locally to use any commands of shub-image tool, as everything is done in an isolated docker container with all the things inside

The logic depends on the PR https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/14, and should be merged / released only after releasing updated `scrapinghub-entrypoint-scrapy`.

WIP I have to fix the tests and add new ones for the changes.