### PR TITLE
Added docker-py to setup install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     },
     include_package_data=True,
     zip_safe=False,
-    install_requires=['click', 'requests', 'six', 'shub'],
+    install_requires=['click', 'requests', 'six', 'shub', 'docker-py'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Hi guys, when installing `shub-image` through `pip` `docker-py` isn't installed but it's required by commands like `shub-image build` which is used often.