### PR TITLE
Docker client returns invalid json

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ setup(
 
 @contextmanager
 def FakeProjectDirectory():
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = os.path.realpath(tempfile.mkdtemp())
     current = os.getcwd()
     os.chdir(tmpdir)
     try:


### PR DESCRIPTION
Workaround for docker-py issue https://github.com/docker/docker-py/issues/1059 - line can contain multiple json objects separated by `\r\n`