### PR TITLE
Fix push when only --username is specified.

### DIFF
--- a/shub_image/push.py
+++ b/shub_image/push.py
@@ -60,6 +60,10 @@ def _execute_push_login(client, image, username, password, email):
     """Login if there're provided credentials for the registry"""
     components = image.split('/')
     registry = components[0] if len(components) == 3 else None
+    if password is None:
+        # Missing password leads to auth request to registry authentication service
+        # without 'account' query parameter which breaks login procedure.
+        password = ' '
     resp = client.login(username=username, password=password,
                         email=email, registry=registry, reauth=False)
     if not (isinstance(resp, dict) and 'username' in resp or

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -47,6 +47,26 @@ class TestPushCli(TestCase):
                 'registry/user/project:test',
                 insecure_registry=False, stream=True)
 
+    def test_cli_with_login_username_only(self, mocked_method):
+        mocked = mock.MagicMock()
+        mocked.login.return_value = {"Status": "Login Succeeded"}
+        mocked.push.return_value = [
+            '{"stream":"In process"}',
+            '{"status":"Successfully pushed"}']
+        mocked_method.return_value = mocked
+        with FakeProjectDirectory() as tmpdir:
+            add_sh_fake_config(tmpdir)
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["dev", "--version", "test", "--username", "apikey"])
+            assert result.exit_code == 0
+            mocked.login.assert_called_with(
+                email=None, password=' ',
+                reauth=False, registry='registry', username='apikey')
+            mocked.push.assert_called_with(
+                'registry/user/project:test',
+                insecure_registry=False, stream=True)
+
     def test_cli_login_fail(self, mocked_method):
         mocked = mock.MagicMock()
         mocked.login.return_value = {"Status": "Login Failed!"}


### PR DESCRIPTION
Missing password leads to auth request to registry authentication service without 'account' query parameter which breaks login procedure.