### PR TITLE
Create setup.py if not exists

### DIFF
--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -64,7 +64,8 @@ def build_cmd(target, version):
 
 def _create_setup_py_if_not_exists():
     closest = closest_file('scrapy.cfg')
-    os.chdir(os.path.dirname(closest))
-    if not os.path.exists('setup.py'):
-        settings = get_config().get('settings', 'default')
-        _create_default_setup_py(settings=settings)
+    with utils.remember_cwd():
+        os.chdir(os.path.dirname(closest))
+        if not os.path.exists('setup.py'):
+            settings = get_config().get('settings', 'default')
+            _create_default_setup_py(settings=settings)

--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -41,7 +41,7 @@ def build_cmd(target, version):
     project_dir = utils.get_project_dir()
     config = utils.load_release_config()
     image = config.get_image(target)
-    _create_setup_py_if_needed()
+    _create_setup_py_if_not_exists()
     image_name = utils.format_image_name(image, version)
     if not os.path.exists(os.path.join(project_dir, 'Dockerfile')):
         raise shub_exceptions.BadParameterException(
@@ -62,7 +62,7 @@ def build_cmd(target, version):
     click.echo("The image {} build is completed.".format(image_name))
 
 
-def _create_setup_py_if_needed():
+def _create_setup_py_if_not_exists():
     closest = closest_file('scrapy.cfg')
     os.chdir(os.path.dirname(closest))
     if not os.path.exists('setup.py'):

--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -5,6 +5,8 @@ import click
 
 from shub import exceptions as shub_exceptions
 from shub.deploy import list_targets
+from shub.deploy import _create_default_setup_py
+from shub.utils import closest_file, get_config
 from shub_image import utils
 
 
@@ -39,6 +41,7 @@ def build_cmd(target, version):
     project_dir = utils.get_project_dir()
     config = utils.load_release_config()
     image = config.get_image(target)
+    _create_setup_py_if_needed()
     image_name = utils.format_image_name(image, version)
     if not os.path.exists(os.path.join(project_dir, 'Dockerfile')):
         raise shub_exceptions.BadParameterException(
@@ -57,3 +60,11 @@ def build_cmd(target, version):
         raise shub_exceptions.RemoteErrorException(
             "Build image operation failed")
     click.echo("The image {} build is completed.".format(image_name))
+
+
+def _create_setup_py_if_needed():
+    closest = closest_file('scrapy.cfg')
+    os.chdir(os.path.dirname(closest))
+    if not os.path.exists('setup.py'):
+        settings = get_config().get('settings', 'default')
+        _create_default_setup_py(settings=settings)

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -2,6 +2,7 @@ import os
 import re
 import click
 import importlib
+import contextlib
 
 from six import string_types
 import ruamel.yaml as yaml
@@ -20,6 +21,15 @@ def debug_log(msg):
     ctx = click.get_current_context(True)
     if ctx and ctx.params.get('debug'):
         click.echo(msg)
+
+
+@contextlib.contextmanager
+def remember_cwd():
+    current_dir = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(current_dir)
 
 
 class ReleaseConfig(shub_config.ShubConfig):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,8 +23,27 @@ class TestBuildCli(TestCase):
             add_scrapy_fake_config(tmpdir)
             add_sh_fake_config(tmpdir)
             add_fake_dockerfile(tmpdir)
+            setup_py_path = os.path.join(tmpdir, 'setup.py')
+            assert not os.path.isfile(setup_py_path)
             runner = CliRunner()
-            result = runner.invoke(cli, ["dev", "-d", "--version", "test"])
+            result = runner.invoke(cli, ["dev", "-d"])
+            assert result.exit_code == 0
+            mocked.build.assert_called_with(
+                path=tmpdir, tag='registry/user/project:1.0')
+            assert os.path.isfile(setup_py_path)
+
+    def test_cli_custom_version(self, mocked_method):
+        mocked = mock.MagicMock()
+        mocked.build.return_value = [
+            '{"stream":"all is ok"}',
+            '{"stream":"Successfully built 12345"}']
+        mocked_method.return_value = mocked
+        with FakeProjectDirectory() as tmpdir:
+            add_scrapy_fake_config(tmpdir)
+            add_sh_fake_config(tmpdir)
+            add_fake_dockerfile(tmpdir)
+            runner = CliRunner()
+            result = runner.invoke(cli, ["dev", "--version", "test"])
             assert result.exit_code == 0
             mocked.build.assert_called_with(
                 path=tmpdir, tag='registry/user/project:test')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,6 @@ endpoints:
   dev: https://dash-fake
 apikeys:
   default: abcdef
-version: GIT
 """
 
 SH_SETUP_FILE = """


### PR DESCRIPTION
shub-image should create default setup.py on build operation, in the same way like shub tool does. It's required for proper versioning between different commands calls when VCS repository isn't initiated yet. For now when there's no VCS repo and no setup.py file, the tool takes current timestamp as version and it leads to errors because as a result each shub-image command is called with different versions.

Review, please.