### PR TITLE
Parse deploy json errors from Dash

### DIFF
--- a/shub_image/deploy.py
+++ b/shub_image/deploy.py
@@ -116,6 +116,8 @@ def _handle_deploy_errors(request):
         reason = content.get('non_field_errors')
         if reason:
             raise ShubException('\n'.join(reason))
+        else:
+            raise ShubException(request.content)
     raise
 
 


### PR DESCRIPTION
Latest changes in Dash introduced minor changes in a way what do we get from Dash in a case of error. The PR fixes this behavior for `shub-image` tool and propagates correct error message.

Please, review.
