### PR TITLE
Do not rely on scrapy.cfg when defining project root directory

### DIFF
--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import click
+import warnings
 
 from shub import exceptions as shub_exceptions
 from shub.deploy import list_targets
@@ -65,9 +66,9 @@ def build_cmd(target, version):
 def _create_setup_py_if_not_exists():
     closest = closest_file('scrapy.cfg')
     # create default setup.py only if scrapy.cfg is found, otherwise
-    # consider it as a non-scrapy/non-python project. FIXME do we need
-    # some warning here in a case if user forgot to create scrapy.cfg?
+    # consider it as a non-scrapy/non-python project
     if not closest:
+        warnings.warn("scrapy.cfg is not found")
         return
     with utils.remember_cwd():
         os.chdir(os.path.dirname(closest))

--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -64,6 +64,10 @@ def build_cmd(target, version):
 
 def _create_setup_py_if_not_exists():
     closest = closest_file('scrapy.cfg')
+    # create default setup.py only if scrapy.cfg is found
+    # otherwise consider it as a non-scrapy & non-python project
+    if not closest:
+        return
     with utils.remember_cwd():
         os.chdir(os.path.dirname(closest))
         if not os.path.exists('setup.py'):

--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -64,8 +64,9 @@ def build_cmd(target, version):
 
 def _create_setup_py_if_not_exists():
     closest = closest_file('scrapy.cfg')
-    # create default setup.py only if scrapy.cfg is found
-    # otherwise consider it as a non-scrapy & non-python project
+    # create default setup.py only if scrapy.cfg is found, otherwise
+    # consider it as a non-scrapy/non-python project. FIXME do we need
+    # some warning here in a case if user forgot to create scrapy.cfg?
     if not closest:
         return
     with utils.remember_cwd():

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -103,7 +103,8 @@ def get_project_dir():
     """
     closest = shub_utils.closest_file('scrapinghub.yml')
     if not closest:
-        raise shub_exceptions.BadConfigException("scrapinghub.yml not found.")
+        raise shub_exceptions.BadConfigException(
+            "Not inside a project: scrapinghub.yml not found.")
     return os.path.dirname(closest)
 
 

--- a/shub_image/utils.py
+++ b/shub_image/utils.py
@@ -101,9 +101,10 @@ def get_project_dir():
     """ A helper to get project root dir.
         Used by init/build command to locate Dockerfile.
     """
-    if not shub_utils.inside_project():
-        raise shub_exceptions.BadConfigException("Not inside a project")
-    return os.path.dirname(shub_utils.closest_file('scrapy.cfg'))
+    closest = shub_utils.closest_file('scrapinghub.yml')
+    if not closest:
+        raise shub_exceptions.BadConfigException("scrapinghub.yml not found.")
+    return os.path.dirname(closest)
 
 
 def get_docker_client(validate=True):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from shub_image.init import _wrap
 
 from .utils import FakeProjectDirectory
 from .utils import add_fake_requirements
+from .utils import add_sh_fake_config
 from .utils import add_scrapy_fake_config
 
 
@@ -35,6 +36,7 @@ class TestInitCli(TestCase):
     def test_cli_default_settings(self):
         with FakeProjectDirectory() as tmpdir:
             add_scrapy_fake_config(tmpdir)
+            add_sh_fake_config(tmpdir)
             runner = CliRunner()
             result = runner.invoke(cli, [], input='no\n')
             assert result.exit_code == 0
@@ -44,6 +46,7 @@ class TestInitCli(TestCase):
     def test_cli_list_recommended_reqs(self):
         with FakeProjectDirectory() as tmpdir:
             add_scrapy_fake_config(tmpdir)
+            add_sh_fake_config(tmpdir)
             runner = CliRunner()
             result = runner.invoke(cli, ["--list-recommended-reqs"])
             assert result.exit_code == 0
@@ -52,6 +55,7 @@ class TestInitCli(TestCase):
     def test_cli_store_dockerfile(self):
         with FakeProjectDirectory() as tmpdir:
             add_scrapy_fake_config(tmpdir)
+            add_sh_fake_config(tmpdir)
             runner = CliRunner()
             result = runner.invoke(cli, [], input='yes\n')
             assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ from shub_image.utils import store_status_url
 from shub_image.utils import load_status_url
 from shub_image.utils import STATUS_FILE_LOCATION
 
-from .utils import FakeProjectDirectory, add_scrapy_fake_config
+from .utils import FakeProjectDirectory, add_sh_fake_config
 
 
 class ReleaseUtilsTest(TestCase):
@@ -40,7 +40,7 @@ class ReleaseUtilsTest(TestCase):
         self.assertRaises(
             shub_exceptions.BadConfigException, get_project_dir)
         with FakeProjectDirectory() as tmpdir:
-            add_scrapy_fake_config(tmpdir)
+            add_sh_fake_config(tmpdir)
             assert get_project_dir() == tmpdir
 
     def test_get_docker_client(self):


### PR DESCRIPTION
shub-image can be used for non-Scrapy / non-Python crawlers as well: it means that scrapy.cfg may not exist and we should rely on some other file to determine a root directory of a project. As scrapinghub.yml is needed for almost all the commands (as it's only file containing all the necessary data about projects/images) - it can be used as such file.

It also means that we shouldn't always try to create a default setup.py for proper versioning if it doesn't exist yet  (see #15) - and do it only if scrapy.cfg exists and we're sure that the project is written with Python.

Review, please.