### PR TITLE
Run shub-image test cmd after building an image

### DIFF
--- a/shub_image/build.py
+++ b/shub_image/build.py
@@ -8,6 +8,7 @@ from shub.deploy import list_targets
 from shub.deploy import _create_default_setup_py
 from shub.utils import closest_file, get_config
 from shub_image import utils
+from shub_image import test as test_mod
 
 
 SHORT_HELP = 'Build release image.'
@@ -32,11 +33,12 @@ shub utils itself).
               callback=list_targets)
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
-def cli(target, debug, version):
-    build_cmd(target, version)
+@click.option("-S", "--skip-tests", help="skip testing image", is_flag=True)
+def cli(target, debug, version, skip_tests):
+    build_cmd(target, version, skip_tests)
 
 
-def build_cmd(target, version):
+def build_cmd(target, version, skip_tests):
     client = utils.get_docker_client()
     project_dir = utils.get_project_dir()
     config = utils.load_release_config()
@@ -59,6 +61,9 @@ def build_cmd(target, version):
         raise shub_exceptions.RemoteErrorException(
             "Build image operation failed")
     click.echo("The image {} build is completed.".format(image_name))
+    # Test the image content after building it
+    if not skip_tests:
+        test_mod.test_cmd(target, version)
 
 
 def _create_setup_py_if_not_exists():

--- a/shub_image/test.py
+++ b/shub_image/test.py
@@ -21,6 +21,10 @@ SH_EP_SCRAPY_WARNING = \
 @click.option("-d", "--debug", help="debug mode", is_flag=True)
 @click.option("--version", help="release version")
 def cli(target, debug, version):
+    test_cmd(target, version)
+
+
+def test_cmd(target, version):
     config = utils.load_release_config()
     image = config.get_image(target)
     version = version or config.get_version()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -14,7 +14,8 @@ from .utils import add_scrapy_fake_config
 @mock.patch('shub_image.utils.get_docker_client')
 class TestBuildCli(TestCase):
 
-    def test_cli(self, mocked_method):
+    @mock.patch('shub_image.test.test_cmd')
+    def test_cli(self, test_mock, mocked_method):
         mocked = mock.MagicMock()
         mocked.build.return_value = [
             {"stream": "all is ok"},
@@ -32,8 +33,10 @@ class TestBuildCli(TestCase):
             mocked.build.assert_called_with(
                 decode=True, path=tmpdir, tag='registry/user/project:1.0')
             assert os.path.isfile(setup_py_path)
+            test_mock.assert_called_with("dev", None)
 
-    def test_cli_custom_version(self, mocked_method):
+    @mock.patch('shub_image.test.test_cmd')
+    def test_cli_custom_version(self, test_mock, mocked_method):
         mocked = mock.MagicMock()
         mocked.build.return_value = [
             {"stream": "all is ok"},
@@ -48,6 +51,7 @@ class TestBuildCli(TestCase):
             assert result.exit_code == 0
             mocked.build.assert_called_with(
                 decode=True, path=tmpdir, tag='registry/user/project:test')
+            test_mock.assert_called_with("dev", "test")
 
     def test_cli_no_dockerfile(self, mocked_method):
         mocked = mock.MagicMock()


### PR DESCRIPTION
The PR adds auto-testing a built image with `test` command.
It's also possible to disable the checks if needed with `-S`/ `--skip-checks` flag.

Review, please.